### PR TITLE
Mesos 0.24.X and 0.25.0 docker build images

### DIFF
--- a/docker/mesos_build/0.24.1/Dockerfile-mesos-module-dvdi-dev-0.24.1
+++ b/docker/mesos_build/0.24.1/Dockerfile-mesos-module-dvdi-dev-0.24.1
@@ -1,0 +1,10 @@
+FROM dvonthenen/mesos-dev:0.24.1
+MAINTAINER David vonThenen (EMCCODE)
+
+ENTRYPOINT cd /isolator/isolator && \
+    ./bootstrap && \
+    rm -Rf build && \
+    mkdir build && \
+    cd build && \
+    ../configure --with-mesos-root=/mesos --with-mesos-build-dir=/mesos && \
+    make

--- a/docker/mesos_build/0.24.1/Dockerfile-mesos-modules-dev-0.24.1
+++ b/docker/mesos_build/0.24.1/Dockerfile-mesos-modules-dev-0.24.1
@@ -1,0 +1,73 @@
+FROM ubuntu:14.04
+MAINTAINER David vonThenen <david.vonthenen@emc.com>
+
+# Install Dependencies
+
+RUN apt-get update -q --fix-missing
+RUN apt-get -qy install software-properties-common # (for add-apt-repository)
+RUN add-apt-repository ppa:george-edison55/cmake-3.x
+RUN apt-get update -q
+RUN apt-cache policy cmake
+RUN apt-get -qy install \
+  build-essential                         \
+  autoconf                                \
+  automake                                \
+  cmake=3.2.2-2ubuntu2~ubuntu14.04.1~ppa1 \
+  ca-certificates                         \
+  gdb                                     \
+  wget                                    \
+  git-core                                \
+  libcurl4-nss-dev                        \
+  libsasl2-dev                            \
+  libtool                                 \
+  libsvn-dev                              \
+  libapr1-dev                             \
+  libgoogle-glog-dev                      \
+  libboost-dev                            \
+  protobuf-compiler                       \
+  libprotobuf-dev                         \
+  make                                    \
+  python                                  \
+  python2.7                               \
+  libpython-dev                           \
+  python-dev                              \
+  python-protobuf                         \
+  python-setuptools                       \
+  heimdal-clients                         \
+  libsasl2-modules-gssapi-heimdal         \
+  unzip                                   \
+  --no-install-recommends
+
+# Install the picojson headers
+RUN wget https://raw.githubusercontent.com/kazuho/picojson/v1.3.0/picojson.h -O /usr/local/include/picojson.h
+
+# Prepare to build Mesos
+RUN mkdir -p /mesos
+RUN mkdir -p /tmp
+RUN mkdir -p /usr/share/java/
+RUN wget http://search.maven.org/remotecontent?filepath=com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar -O protobuf.jar
+RUN mv protobuf.jar /usr/share/java/
+
+WORKDIR /mesos
+
+# Clone Mesos (master branch)
+RUN git clone git://git.apache.org/mesos.git /mesos
+RUN git checkout 44873806c2bb55da37e9adbece938274d8cd7c48
+RUN git log -n 1
+
+# Bootstrap
+RUN ./bootstrap
+
+# Configure
+RUN mkdir build && cd build && ../configure --disable-java --disable-optimize --without-included-zookeeper --with-glog=/usr/local --with-protobuf=/usr --with-boost=/usr/local
+
+# Build Mesos
+RUN cd build && make -j 8 install
+
+# Install python eggs
+RUN easy_install /mesos/build/src/python/dist/mesos.interface-*.egg
+RUN easy_install /mesos/build/src/python/dist/mesos.native-*.egg
+
+# Extra
+
+RUN cd /mesos/3rdparty/libprocess/3rdparty && tar -zxvf protobuf-2.5.0.tar.gz && cd protobuf-2.5.0 && ./configure && make -j 8

--- a/docker/mesos_build/0.25.0/Dockerfile-mesos-module-dvdi-dev-0.25.0
+++ b/docker/mesos_build/0.25.0/Dockerfile-mesos-module-dvdi-dev-0.25.0
@@ -1,0 +1,10 @@
+FROM dvonthenen/mesos-dev:0.25.0
+MAINTAINER David vonThenen (EMCCODE)
+
+ENTRYPOINT cd /isolator/isolator && \
+    ./bootstrap && \
+    rm -Rf build && \
+    mkdir build && \
+    cd build && \
+    ../configure --with-mesos-root=/mesos --with-mesos-build-dir=/mesos && \
+    make

--- a/docker/mesos_build/0.25.0/Dockerfile-mesos-modules-dev-0.25.0
+++ b/docker/mesos_build/0.25.0/Dockerfile-mesos-modules-dev-0.25.0
@@ -1,0 +1,73 @@
+FROM ubuntu:14.04
+MAINTAINER David vonThenen <david.vonthenen@emc.com>
+
+# Install Dependencies
+
+RUN apt-get update -q --fix-missing
+RUN apt-get -qy install software-properties-common # (for add-apt-repository)
+RUN add-apt-repository ppa:george-edison55/cmake-3.x
+RUN apt-get update -q
+RUN apt-cache policy cmake
+RUN apt-get -qy install \
+  build-essential                         \
+  autoconf                                \
+  automake                                \
+  cmake=3.2.2-2ubuntu2~ubuntu14.04.1~ppa1 \
+  ca-certificates                         \
+  gdb                                     \
+  wget                                    \
+  git-core                                \
+  libcurl4-nss-dev                        \
+  libsasl2-dev                            \
+  libtool                                 \
+  libsvn-dev                              \
+  libapr1-dev                             \
+  libgoogle-glog-dev                      \
+  libboost-dev                            \
+  protobuf-compiler                       \
+  libprotobuf-dev                         \
+  make                                    \
+  python                                  \
+  python2.7                               \
+  libpython-dev                           \
+  python-dev                              \
+  python-protobuf                         \
+  python-setuptools                       \
+  heimdal-clients                         \
+  libsasl2-modules-gssapi-heimdal         \
+  unzip                                   \
+  --no-install-recommends
+
+# Install the picojson headers
+RUN wget https://raw.githubusercontent.com/kazuho/picojson/v1.3.0/picojson.h -O /usr/local/include/picojson.h
+
+# Prepare to build Mesos
+RUN mkdir -p /mesos
+RUN mkdir -p /tmp
+RUN mkdir -p /usr/share/java/
+RUN wget http://search.maven.org/remotecontent?filepath=com/google/protobuf/protobuf-java/2.5.0/protobuf-java-2.5.0.jar -O protobuf.jar
+RUN mv protobuf.jar /usr/share/java/
+
+WORKDIR /mesos
+
+# Clone Mesos (master branch)
+RUN git clone git://git.apache.org/mesos.git /mesos
+RUN git checkout 2dd7f7ee115fe00b8e098b0a10762a4fa8f4600f
+RUN git log -n 1
+
+# Bootstrap
+RUN ./bootstrap
+
+# Configure
+RUN mkdir build && cd build && ../configure --disable-java --disable-optimize --without-included-zookeeper --with-glog=/usr/local --with-protobuf=/usr --with-boost=/usr/local
+
+# Build Mesos
+RUN cd build && make -j 8 install
+
+# Install python eggs
+RUN easy_install /mesos/build/src/python/dist/mesos.interface-*.egg
+RUN easy_install /mesos/build/src/python/dist/mesos.native-*.egg
+
+# Extra
+
+RUN cd /mesos/3rdparty/libprocess/3rdparty && tar -zxvf protobuf-2.5.0.tar.gz && cd protobuf-2.5.0 && ./configure && make -j 8


### PR DESCRIPTION
Added docker files used to create the Mesos 0.24.X and 0.25.0 docker build images. Might be useful to someone else.